### PR TITLE
Add advanced filtering and PDF viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. The interface lets you upload many PDFs at once, search them by keywords or custom filters (such as education or college name), and view or download the filtered files.
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
 

--- a/src/app/api/pdf/download/route.ts
+++ b/src/app/api/pdf/download/route.ts
@@ -2,20 +2,6 @@ import { NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
 import { getPdfById } from '@/lib/db';
 
-async function fetchPdfById(id: string): Promise<Pdf | null> {
-  if (id === 'example') {
-    return {
-      path: '/path/to/example.pdf',
-      filename: 'example.pdf',
-    };
-  }
-  return null;
-}
-
-interface Pdf {
-  path: string;
-  filename: string;
-}
 
 export async function GET(request: { url: string | URL; }) {
   try {
@@ -29,7 +15,8 @@ export async function GET(request: { url: string | URL; }) {
       );
     }
     
-    const pdf = await fetchPdfById(id);
+    const view = searchParams.get('view');
+    const pdf = await getPdfById(id);
     
     if (!pdf) {
       return NextResponse.json(
@@ -44,7 +31,8 @@ export async function GET(request: { url: string | URL; }) {
       const response = new NextResponse(fileBuffer);
       
       response.headers.set('Content-Type', 'application/pdf');
-      response.headers.set('Content-Disposition', `attachment; filename="${encodeURIComponent(pdf.filename)}"`);
+      const disposition = view === '1' ? 'inline' : 'attachment';
+      response.headers.set('Content-Disposition', `${disposition}; filename="${encodeURIComponent(pdf.filename)}"`);
       
       return response;
     } catch (fileError) {

--- a/src/app/api/pdf/search/route.ts
+++ b/src/app/api/pdf/search/route.ts
@@ -4,16 +4,9 @@ import { searchPdfsByKeywords } from '@/lib/db';
 export async function POST(request: { json: () => any; }) {
   try {
     const data = await request.json();
-    const { keywords } = data;
-    
-    if (!keywords || !Array.isArray(keywords) || keywords.length === 0) {
-      return NextResponse.json(
-        { message: 'No keywords provided for search' },
-        { status: 400 }
-      );
-    }
-    
-    const results = await searchPdfsByKeywords(keywords);
+    const { keywords = [], filters = {} } = data;
+
+    const results = await searchPdfsByKeywords(Array.isArray(keywords) ? keywords : [], filters);
     
     return NextResponse.json({
       message: `Found ${results.length} matching documents`,

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -4,10 +4,12 @@ import { useState, useEffect } from 'react';
 import FileUpload from '@/components/FileUpload';
 import KeywordInput from '@/components/KeywordInput';
 import ResultsList from '@/components/ResultsList';
+import FilterInput from '@/components/FilterInput';
 
 export default function Home() {
   const [pdfs, setPdfs] = useState<any[]>([]);
   const [keywords, setKeywords] = useState([]);
+  const [filters, setFilters] = useState([]);
   const [filteredPdfs, setFilteredPdfs] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState('');
@@ -30,11 +32,11 @@ export default function Home() {
 
   useEffect(() => {
     const searchPdfs = async () => {
-      if (keywords.length === 0) {
+      if (keywords.length === 0 && filters.length === 0) {
         setFilteredPdfs([]);
+        setMessage('');
         return;
       }
-
       setIsLoading(true);
       try {
         const response = await fetch('/api/pdf/search', {
@@ -42,7 +44,7 @@ export default function Home() {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ keywords }),
+          body: JSON.stringify({ keywords, filters }),
         });
 
         if (response.ok) {
@@ -61,7 +63,7 @@ export default function Home() {
     };
 
     searchPdfs();
-  }, [keywords]);
+  }, [keywords, filters]);
 
   const handleFileUpload = async (uploadedFiles: any[]) => {
     setIsLoading(true);
@@ -110,14 +112,18 @@ export default function Home() {
             </div>
           )}
           
-          <div className="mt-8">
-            <h2 className="text-xl font-semibold mb-4">Enter Keywords</h2>
-            <KeywordInput 
-              onKeywordsChange={setKeywords}
-              isLoading={isLoading}
-            />
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold mb-4">Enter Keywords</h2>
+          <KeywordInput
+            onKeywordsChange={setKeywords}
+            isLoading={isLoading}
+          />
+          <div className="mt-6">
+            <h3 className="text-lg font-semibold mb-2">Add Filters</h3>
+            <FilterInput onFiltersChange={setFilters} isLoading={isLoading} />
           </div>
         </div>
+      </div>
         
         <div>
           <h2 className="text-xl font-semibold mb-4">Results</h2>

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -27,7 +27,9 @@ export default function FileUpload({ onUpload, isLoading }) {
     onDrop,
     accept: {
       'application/pdf': ['.pdf']
-    }
+    },
+    maxFiles: 200,
+    multiple: true
   });
 
   const removeFile = (index) => {

--- a/src/components/FilterInput.js
+++ b/src/components/FilterInput.js
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { X, Plus } from 'lucide-react';
+
+export default function FilterInput({ onFiltersChange, isLoading }) {
+  const [field, setField] = useState('');
+  const [value, setValue] = useState('');
+  const [filters, setFilters] = useState([]);
+
+  const addFilter = () => {
+    const f = field.trim();
+    const v = value.trim();
+    if (!f || !v) return;
+    const updated = [...filters, { field: f, value: v }];
+    setFilters(updated);
+    onFiltersChange(updated);
+    setField('');
+    setValue('');
+  };
+
+  const removeFilter = (index) => {
+    const updated = filters.filter((_, i) => i !== index);
+    setFilters(updated);
+    onFiltersChange(updated);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          placeholder="Filter name"
+          value={field}
+          onChange={e => setField(e.target.value)}
+          className="flex-1 px-3 py-2 border rounded-md focus:outline-none"
+          disabled={isLoading}
+        />
+        <input
+          type="text"
+          placeholder="Filter value"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          className="flex-1 px-3 py-2 border rounded-md focus:outline-none"
+          disabled={isLoading}
+        />
+        <button
+          onClick={addFilter}
+          disabled={isLoading || !field.trim() || !value.trim()}
+          className={`px-3 py-2 rounded-md ${isLoading || !field.trim() || !value.trim() ? 'bg-gray-300 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700 text-white'}`}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+      {filters.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {filters.map((f, i) => (
+            <span key={i} className="flex items-center bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm">
+              {f.field}: {f.value}
+              <button onClick={() => removeFilter(i)} className="ml-1 text-blue-600 hover:text-blue-800" disabled={isLoading}>
+                <X className="h-4 w-4" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PdfItem.js
+++ b/src/components/PdfItem.js
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Download, ExternalLink, Clipboard, Check } from 'lucide-react';
+import { Download, ExternalLink, Clipboard, Check, Eye, X as Close } from 'lucide-react';
 
 export default function PdfItem({ pdf, keywords }) {
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [showViewer, setShowViewer] = useState(false);
 
   useEffect(() => {
     const fetchContent = async () => {
@@ -103,14 +104,21 @@ export default function PdfItem({ pdf, keywords }) {
           <div className="mb-3 flex justify-between">
             <h3 className="font-medium">Document Preview</h3>
             <div className="flex gap-2">
-              <button 
+              <button
                 onClick={copyToClipboard}
                 className="text-gray-500 hover:text-gray-700 p-1"
                 title="Copy content"
               >
                 {copied ? <Check className="h-5 w-5 text-green-500" /> : <Clipboard className="h-5 w-5" />}
               </button>
-              <a 
+              <button
+                onClick={() => setShowViewer(true)}
+                className="text-gray-500 hover:text-gray-700 p-1"
+                title="View PDF"
+              >
+                <Eye className="h-5 w-5" />
+              </button>
+              <a
                 href={`/api/pdf/download?id=${pdf.id}`}
                 className="text-gray-500 hover:text-gray-700 p-1"
                 title="Download PDF"
@@ -130,6 +138,22 @@ export default function PdfItem({ pdf, keywords }) {
           ) : (
             <div className="p-3 border rounded bg-white max-h-60 overflow-y-auto text-sm">
               {content ? content.substring(0, 500) + '...' : 'No content available'}
+            </div>
+          )}
+          {showViewer && (
+            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+              <div className="bg-white rounded shadow-lg w-11/12 h-5/6 relative">
+                <button
+                  onClick={() => setShowViewer(false)}
+                  className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+                >
+                  <Close className="h-5 w-5" />
+                </button>
+                <iframe
+                  src={`/api/pdf/download?id=${pdf.id}&view=1`}
+                  className="w-full h-full"
+                />
+              </div>
             </div>
           )}
         </>

--- a/src/components/ResultsList.js
+++ b/src/components/ResultsList.js
@@ -25,8 +25,8 @@ export default function ResultsList({ pdfs, keywords, isFiltered, isLoading }) {
       <div className="flex flex-col items-center justify-center p-8 border rounded-lg bg-gray-50">
         <FileText className="h-12 w-12 text-gray-400" />
         <p className="mt-4 text-gray-600">
-          {isFiltered 
-            ? 'No PDFs match your keywords' 
+          {isFiltered
+            ? 'No PDFs match your search criteria'
             : 'No PDFs uploaded yet. Start by uploading some files.'}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- add `FilterInput` for custom filters
- allow selecting up to 200 PDFs in `FileUpload`
- enable filtering by keywords and custom filters on the server
- add inline PDF viewer with download option
- improve messages and README

## Testing
- `npm run build` *(fails: next not found)*